### PR TITLE
update gsinfo requirements

### DIFF
--- a/gsinfo/info.json
+++ b/gsinfo/info.json
@@ -6,5 +6,5 @@
 	"NAME" : "GSInfo",
 	"INSTALL_MSG" : "Thanks for installing the gsinfo cog. All pre-requisits should be installed, if not, run this command on your server:\n`pip install -U https://github.com/Shigbeard/python-valve/archive/master.zip`\n\n**Commands**\n```[p]gsinfo [<ip:port> | <ip> (port) | <url>] | Get info about a game server.\n[p]gsplayers [<ip:port> | <ip> (port) | <url>] | Displays info about players on a server.```\nPlease note, there are some issues with listing players that occurs when there is a player with a funky steam name. I do my best to filter out dodgy names, but some slip through the cracks and they make Discord angry. If you get HTTP 400 errors or BAD_REQUEST errors, thats why.",
 	"TAGS" : ["games","utility","tools","gaming","stats","utilities","statistics","info","tool"],
-	"REQUIREMENTS" : ["-U https://github.com/Shigbeard/python-valve/archive/master.zip","beautifulsoup4"]
+	"REQUIREMENTS" : ["python-valve","beautifulsoup4"]
 }


### PR DESCRIPTION
Using github url as requirement is no longer working in newest version of redbot.